### PR TITLE
Add example for routing delay message

### DIFF
--- a/clients/common/src/main/java/io/streamnative/examples/common/ConsumerFlags.java
+++ b/clients/common/src/main/java/io/streamnative/examples/common/ConsumerFlags.java
@@ -65,4 +65,12 @@ public class ConsumerFlags extends TopicFlags {
     )
     public AckType ackType = null;
 
+    @Parameter(
+        names = {
+                "-ppn", "--print-partition-num"
+        },
+        description = "Set is print partition num"
+    )
+    public boolean printPartitionNum = false;
+
 }

--- a/clients/pubsub/examples/delayed-message.md
+++ b/clients/pubsub/examples/delayed-message.md
@@ -24,7 +24,17 @@ It runs in a loop receiving messages.
 
 - [Delayed Message Producer With Message Router](../src/main/java/io/streamnative/examples/pubsub/DelayedMessageProducerWithMessageRouterExample.java)
 
-It will publish 5 message immediately and publish another 5 messages delayed 1 ~ 5 seconds mod by partition nums.
+It will publish 10 message immediately and publish another 10 messages delayed 0 ~ 90 seconds, the similar delay time will put same partition. Such as:
+
+Delayed message of 0 seconds ~ 30 seconds will be put in partition 0.
+Delayed message of 30 seconds ~ 1 minutes will be put in partition 1.
+Delayed message of 1 minutes ~ 10 minutes will be put in partition 2.
+Delayed message of 10 minutes ~ 1 hours will be put in partition 3.
+Delayed message of 1 hours ~ 12 hours will be put in partition 4.
+Delayed message of 12 hours ~ 1 days will be put in partition 5.
+Delayed message of 1 days ~ 3 days will be put in partition 6.
+Delayed message of 3 days ~ 7 days will be put in partition 7.
+Delayed message delay time after 7 days will be put in partition 8.
 
 - Expected Result
 
@@ -111,9 +121,9 @@ in Pulsar documentation to start a Pulsar standalone locally.
     Consumer Received message : DeliverAt message 4; Difference between publish time and receive time = 5 seconds
     ```
 
-9. Create a topic has 10 partitions
+9. Create a topic has 9 partitions
    ```shell
-   bin/pulsar-admin topics create-partitioned-topic persistent://public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic -p 10
+   bin/pulsar-admin topics create-partitioned-topic persistent://public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic -p 9
    ```
 
 10. Run the consumer example to wait for receiving the produced message from topic `public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic`
@@ -123,28 +133,40 @@ in Pulsar documentation to start a Pulsar standalone locally.
      -t public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic \
      -sn test-sub \
      -st Shared \
-     -n 0
+     -n 0 \
+     -ppn
    ```
 
 11. Open another terminal, run the DelayedMessageProducerWithMessageRouterExample example to produce 10 messages to the topic `public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic`.
-    The producer example will produce the first 5 messages immediately and produce 5 messages delayed 10 seconds using a custom message router.
+    The producer example will produce the first 10 messages immediately and produce 10 messages delayed 0 ~ 90 seconds using a custom message router.
    ```shell
    java -cp pubsub/target/pulsar-pubsub-examples.jar \
      io.streamnative.examples.pubsub.DelayedMessageProducerWithMessageRouterExample \
-     -t public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic -n 5
+     -t public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic -n 10
    ```
 
 12. Go to the terminal running the consumer example, you will see the following output. The consumer example successfully received
-    10 messages. For not using `deliverAfter`, the difference between publish time and receive time is 0 seconds. For using `deliverAfter`, the time is equals partition num.
+    20 messages. For not using `deliverAfter`, the difference between publish time and receive time is 0 seconds. For using `deliverAfter`, the similar delay time will put same partition.
     ```shell
-      Consumer Received message : Immediate delivery message 2, Partition : 1; Difference between publish time and receive time = 0 seconds
-      Consumer Received message : Immediate delivery message 0, Partition : 4; Difference between publish time and receive time = 0 seconds
-      Consumer Received message : Immediate delivery message 4, Partition : 9; Difference between publish time and receive time = 0 seconds
-      Consumer Received message : Immediate delivery message 3, Partition : 3; Difference between publish time and receive time = 0 seconds
-      Consumer Received message : Immediate delivery message 1, Partition : 4; Difference between publish time and receive time = 0 seconds
-      Consumer Received message : DeliverAfter message 0, delay time : 1, Partition : 1; Difference between publish time and receive time = 1 seconds
-      Consumer Received message : DeliverAfter message 1, delay time : 2, Partition : 2; Difference between publish time and receive time = 2 seconds
-      Consumer Received message : DeliverAfter message 2, delay time : 3, Partition : 2; Difference between publish time and receive time = 3 seconds
-      Consumer Received message : DeliverAfter message 3, delay time : 4, Partition : 4; Difference between publish time and receive time = 4 seconds
-      Consumer Received message : DeliverAfter message 4, delay time : 5, Partition : 5; Difference between publish time and receive time = 5 seconds
+      Consumer Received message : Immediate delivery message 5, Partition : 1; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 3, Partition : 8; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 4, Partition : 0; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 7, Partition : 3; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 6, Partition : 2; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 2, Partition : 7; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 1, Partition : 6; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 8, Partition : 4; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 0, Partition : 5; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 9, Partition : 5; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : DeliverAfter message 0, delay time : 0, Partition : 0; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : DeliverAfter message 1, delay time : 10, Partition : 0; Difference between publish time and receive time = 10 seconds
+      Consumer Received message : DeliverAfter message 2, delay time : 20, Partition : 0; Difference between publish time and receive time = 20 seconds
+      Consumer Received message : DeliverAfter message 3, delay time : 30, Partition : 0; Difference between publish time and receive time = 30 seconds
+      Consumer Received message : DeliverAfter message 4, delay time : 40, Partition : 1; Difference between publish time and receive time = 40 seconds
+      Consumer Received message : DeliverAfter message 5, delay time : 50, Partition : 1; Difference between publish time and receive time = 50 seconds
+      Consumer Received message : DeliverAfter message 6, delay time : 60, Partition : 1; Difference between publish time and receive time = 60 seconds
+      Consumer Received message : DeliverAfter message 7, delay time : 70, Partition : 2; Difference between publish time and receive time = 70 seconds
+      Consumer Received message : DeliverAfter message 8, delay time : 80, Partition : 2; Difference between publish time and receive time = 80 seconds
+      Consumer Received message : DeliverAfter message 9, delay time : 90, Partition : 2; Difference between publish time and receive time = 90 seconds
+
     ```

--- a/clients/pubsub/examples/delayed-message.md
+++ b/clients/pubsub/examples/delayed-message.md
@@ -22,6 +22,10 @@ It will publish 5 messages immediately and publish another 5 messages delayed 5 
 
 It runs in a loop receiving messages.
 
+- [Delayed Message Producer With Message Router](../src/main/java/io/streamnative/examples/pubsub/DelayedMessageProducerWithMessageRouterExample.java)
+
+It will publish 5 message immediately and publish another 5 messages delayed 1 ~ 5 seconds mod by partition nums.
+
 - Expected Result
 
 Consumer will receive no delayed messages immediately and receive delayed messages after 5 seconds.
@@ -105,4 +109,42 @@ in Pulsar documentation to start a Pulsar standalone locally.
     Consumer Received message : DeliverAt message 2; Difference between publish time and receive time = 5 seconds
     Consumer Received message : DeliverAt message 3; Difference between publish time and receive time = 5 seconds
     Consumer Received message : DeliverAt message 4; Difference between publish time and receive time = 5 seconds
+    ```
+
+9. Create a topic has 10 partitions
+   ```shell
+   bin/pulsar-admin topics create-partitioned-topic persistent://public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic -p 10
+   ```
+
+10. Run the consumer example to wait for receiving the produced message from topic `public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic`
+   ```shell
+   java -cp pubsub/target/pulsar-pubsub-examples.jar \
+     io.streamnative.examples.pubsub.DelayedMessageConsumerExample \
+     -t public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic \
+     -sn test-sub \
+     -st Shared \
+     -n 0
+   ```
+
+11. Open another terminal, run the DelayedMessageProducerWithMessageRouterExample example to produce 10 messages to the topic `public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic`.
+    The producer example will produce the first 5 messages immediately and produce 5 messages delayed 10 seconds using a custom message router.
+   ```shell
+   java -cp pubsub/target/pulsar-pubsub-examples.jar \
+     io.streamnative.examples.pubsub.DelayedMessageProducerWithMessageRouterExample \
+     -t public/delayed-delivery-example/delayed-message-producer-with-message-router-example-topic -n 5
+   ```
+
+12. Go to the terminal running the consumer example, you will see the following output. The consumer example successfully received
+    10 messages. For not using `deliverAfter`, the difference between publish time and receive time is 0 seconds. For using `deliverAfter`, the time is equals partition num.
+    ```shell
+      Consumer Received message : Immediate delivery message 2, Partition : 1; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 0, Partition : 4; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 4, Partition : 9; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 3, Partition : 3; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : Immediate delivery message 1, Partition : 4; Difference between publish time and receive time = 0 seconds
+      Consumer Received message : DeliverAfter message 0, delay time : 1, Partition : 1; Difference between publish time and receive time = 1 seconds
+      Consumer Received message : DeliverAfter message 1, delay time : 2, Partition : 2; Difference between publish time and receive time = 2 seconds
+      Consumer Received message : DeliverAfter message 2, delay time : 3, Partition : 2; Difference between publish time and receive time = 3 seconds
+      Consumer Received message : DeliverAfter message 3, delay time : 4, Partition : 4; Difference between publish time and receive time = 4 seconds
+      Consumer Received message : DeliverAfter message 4, delay time : 5, Partition : 5; Difference between publish time and receive time = 5 seconds
     ```

--- a/clients/pubsub/src/main/java/io/streamnative/examples/pubsub/DelayedMessageConsumerExample.java
+++ b/clients/pubsub/src/main/java/io/streamnative/examples/pubsub/DelayedMessageConsumerExample.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.naming.TopicName;
 
 /**
  * Example that demonstrates how to use delayed message delivery feature.
@@ -68,10 +69,17 @@ public class DelayedMessageConsumerExample extends ExampleRunner<ConsumerFlags> 
                     .subscribe()) {
                 while (flags.numMessages <= 0 || numReceived < flags.numMessages) {
                     Message<String> msg = consumer.receive();
-                    System.out.println("Consumer Received message : " + msg.getValue()
-                            + "; Difference between publish time and receive time = "
-                            + (System.currentTimeMillis() - msg.getPublishTime()) / 1000
-                            + " seconds");
+                    StringBuilder consumerInfo = new StringBuilder();
+                    consumerInfo.append("Consumer Received message : ").append(msg.getValue());
+
+                    if (flags.printPartitionNum) {
+                        consumerInfo.append(", Partition : ")
+                                .append(TopicName.getPartitionIndex(msg.getTopicName()));
+                    }
+                    consumerInfo.append("; Difference between publish time and receive time = ")
+                            .append((System.currentTimeMillis() - msg.getPublishTime()) / 1000)
+                            .append(" seconds");
+                    System.out.println(consumerInfo);
                     consumer.acknowledge(msg);
                     ++numReceived;
                 }

--- a/clients/pubsub/src/main/java/io/streamnative/examples/pubsub/DelayedMessageProducerWithMessageRouterExample.java
+++ b/clients/pubsub/src/main/java/io/streamnative/examples/pubsub/DelayedMessageProducerWithMessageRouterExample.java
@@ -126,7 +126,7 @@ public class DelayedMessageProducerWithMessageRouterExample extends ExampleRunne
                 }
                 producer.flush();
 
-                // Delay 1 ~ numMessages seconds using DeliverAfter
+                // Delay 0 ~ numMessages * 10 seconds using DeliverAfter
                 for (int i = 0; i < numMessages; i++) {
                     int delayTime = i * 10;
                     producer.newMessage()

--- a/clients/pubsub/src/main/java/io/streamnative/examples/pubsub/DelayedMessageProducerWithMessageRouterExample.java
+++ b/clients/pubsub/src/main/java/io/streamnative/examples/pubsub/DelayedMessageProducerWithMessageRouterExample.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.examples.pubsub;
+
+import io.streamnative.examples.common.ExampleRunner;
+import io.streamnative.examples.common.ProducerFlags;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageRouter;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TopicMetadata;
+import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
+import org.apache.pulsar.client.impl.Hash;
+import org.apache.pulsar.client.impl.JavaStringHash;
+import org.apache.pulsar.client.impl.MessageImpl;
+
+/**
+ * Example that demonstrates how to custom a message router use delayed message delivery feature.
+ **/
+@Slf4j
+public class DelayedMessageProducerWithMessageRouterExample extends ExampleRunner<ProducerFlags> {
+
+    public static void main(String[] args) {
+        DelayedMessageProducerWithMessageRouterExample example =
+                new DelayedMessageProducerWithMessageRouterExample();
+
+        example.run(args);
+    }
+
+    @Override
+    protected String name() {
+        return DelayedMessageProducerWithMessageRouterExample.class.getSimpleName();
+    }
+
+    @Override
+    protected String description() {
+        return "An example that demonstrates how to custom a message router use delayed message delivery feature.";
+    }
+
+    @Override
+    protected ProducerFlags flags() {
+        return new ProducerFlags();
+    }
+
+    @Override
+    protected void run(ProducerFlags flags) throws Exception {
+        try (PulsarClient client = PulsarClient.builder()
+                .serviceUrl(flags.binaryServiceUrl)
+                .build()) {
+
+            try (Producer<String> producer = client.newProducer(Schema.STRING)
+                    .topic(flags.topic)
+                    .messageRoutingMode(MessageRoutingMode.CustomPartition)
+                    .messageRouter(new CustomMessageRouter()).create()) {
+                final int numMessages = Math.max(flags.numMessages, 1);
+
+                // Immediate delivery
+                for (int i = 0; i < numMessages; i++) {
+                    producer.newMessage()
+                            .value("Immediate delivery message " + i)
+                            .sendAsync();
+                }
+                producer.flush();
+
+                // Delay 1 ~ numMessages seconds using DeliverAfter
+                for (int i = 0; i < numMessages; i++) {
+                    int delayTime = (i % numMessages) + 1;
+                    producer.newMessage()
+                            .value("DeliverAfter message " + i + ", delay time : " + delayTime)
+                            .deliverAfter(delayTime, TimeUnit.SECONDS)
+                            .sendAsync();
+                }
+                producer.flush();
+            }
+
+        }
+    }
+
+    private static class CustomMessageRouter implements MessageRouter {
+
+        private final Hash hash = JavaStringHash.getInstance();
+
+        @Override
+        public int choosePartition(Message<?> msg, TopicMetadata metadata) {
+            if (msg instanceof MessageImpl) {
+                MessageImpl<?> message = (MessageImpl<?>) msg;
+                long deliverAtTime = message.getMessageBuilder().getDeliverAtTime();
+                // We can route message by deliverAtTime if deliverAtTime exists,
+                // in this case just mod by partition nums.
+                if (deliverAtTime != 0) {
+                    long deliverAtTimeSeconds =
+                            Duration.ofMillis(deliverAtTime - System.currentTimeMillis()).getSeconds();
+                    if (deliverAtTimeSeconds < 0) {
+                        deliverAtTimeSeconds = 0;
+                    }
+                    return (int) (deliverAtTimeSeconds % metadata.numPartitions());
+                }
+            }
+            // When message is normal message run this follow strategy.
+            // Just for demo, in production you may need choose suitable strategy.
+            if (msg.hasKey() && msg.getSequenceId() < 0) {
+                return hash.makeHash(msg.getKeyBytes()) % metadata.numPartitions();
+            }
+            if (msg.getSequenceId() >= 0) {
+                return (int) (msg.getSequenceId() % metadata.numPartitions());
+            }
+            return hash.makeHash(msg.getData()) % metadata.numPartitions();
+        }
+    }
+}

--- a/clients/pubsub/src/main/java/io/streamnative/examples/pubsub/DelayedMessageProducerWithMessageRouterExample.java
+++ b/clients/pubsub/src/main/java/io/streamnative/examples/pubsub/DelayedMessageProducerWithMessageRouterExample.java
@@ -89,21 +89,6 @@ public class DelayedMessageProducerWithMessageRouterExample extends ExampleRunne
                 new DelayedMessageProducerWithMessageRouterExample();
 
         example.run(args);
-//        int partitionByDelayTime = choosePartitionByDelayTime(0);
-//        System.out.println(partitionByDelayTime == 0);
-//        partitionByDelayTime = choosePartitionByDelayTime(Duration.ofMinutes(1).toMillis());
-//        System.out.println(partitionByDelayTime == 0);
-//        partitionByDelayTime = choosePartitionByDelayTime(Duration.ofMinutes(2).toMillis());
-//        System.out.println(partitionByDelayTime == 1);
-//        partitionByDelayTime = choosePartitionByDelayTime(Duration.ofMinutes(10).toMillis());
-//        System.out.println(partitionByDelayTime == 1);
-//        partitionByDelayTime = choosePartitionByDelayTime(Duration.ofMinutes(11).toMillis());
-//        System.out.println(partitionByDelayTime == 2);
-//        partitionByDelayTime = choosePartitionByDelayTime(Long.MAX_VALUE - 1);
-//        System.out.println(partitionByDelayTime == 7);
-//        partitionByDelayTime = choosePartitionByDelayTime(Long.MAX_VALUE);
-//        System.out.println(partitionByDelayTime == 7);
-
     }
 
     @Override


### PR DESCRIPTION
## Motivation
#85 Add example for routing delay messages to different partitions.

## Modifications
1. Add an example produce delay message and routing by delay time.
2. Add consumer flag to print partitionNum.
