### PR TITLE
Add C++ and Python example for OAuth2 with scope field

### DIFF
--- a/cloud/cpp/ConnectByOAuth2.cc
+++ b/cloud/cpp/ConnectByOAuth2.cc
@@ -17,21 +17,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <iostream>
 #include <pulsar/Authentication.h>
 #include <pulsar/Client.h>
 
 using namespace pulsar;
 
 int main() {
-    ClientConfiguration config;
-    std::string oauthParams = R"({
+    // C++ client provides two ways to construct an AuthOauth2 object
+    // 1. Create by ParamMap (std::map<std::string, std::string>), this way is more simple and efficient
+    ParamMap params;
+    params["issuer_url"] = "http://cloud/oauth/token";
+    params["private_key"] = "/resources/authentication/token/cpp_credentials_file.json";
+    params["audience"] = "https://cloud.auth0.com/api/v2/";
+    params["scope"] = "api://pulsar-cluster-1/.default";  // scope is optional
+
+    Client client1("pulsar+ssl://streamnative.cloud:6651",
+                   ClientConfiguration().setAuth(AuthOauth2::create(params)));
+    client1.close();
+
+    // 2. Create by JSON string, it will be parsed to a ParamMap internally
+    std::string paramsJson = R"({
     "issuer_url": "https://cloud/oauth/token",
     "private_key": "/resources/authentication/token/cpp_credentials_file.json",
-    "audience": "https://cloud.auth0.com/api/v2/"})";
+    "audience": "https://cloud.auth0.com/api/v2/",
+    "scope": "api://pulsar-cluster-1/.default"})";  // scope is optional
 
-    config.setAuth(pulsar::AuthOauth2::create(params));
-
-    Client client("pulsar+ssl://streamnative.cloud:6651", config);
-    client.close();
+    Client client2("pulsar+ssl://streamnative.cloud:6651",
+                   ClientConfiguration().setAuth(AuthOauth2::create(paramsJson)));
+    client2.close();
 }

--- a/cloud/cpp/README.md
+++ b/cloud/cpp/README.md
@@ -6,6 +6,8 @@ Produce message to and consume message from a Pulsar cluster using [Apache pulsa
 
 - CPP Client: 2.6.1+
 
+Since 2.8.1.10, C++ client has supported configuring `scope` field for OAuth2 authentication.
+
 ## Linux
 
 Since 2.1.0 release, Pulsar ships pre-built RPM and Debian packages. You can download and install those packages directly.

--- a/cloud/python/README.md
+++ b/cloud/python/README.md
@@ -77,6 +77,24 @@ sudo python setup.py install
     Produce message 'message 9 from oauth2 producer' to the pulsar service successfully.
     ```
 
+> *NOTE*
+>
+> Since 2.8.1.10, Python client has supported configuring `scope` field for OAuth2 authentication.
+>
+> For example,
+>
+> ```shell
+> python3 OAuth2Producer.py \
+>     -su "pulsar+ssl://streamnative.cloud:6651 \
+>     -t my-topic -n 10 --auth-params '{
+>     "issuer_url": "https://auth.streamnative.cloud",
+>     "private_key": "/path/to/private.key",
+>     "audience": "urn:sn:pulsar:test-organization-name:test-pulsar-instance-name"}',
+>     "scope": "api://pulsar-cluster-1/.default"
+> }'
+> ```
+
+
 ## Connect to the Pulsar cluster with Token authentication plugin
 
 In this example, the Python producer publishes data to the `my-topic` in your Pulsar cluster. The consumer receives the message from the `my-topic` and `acknowledges` each received message.


### PR DESCRIPTION
These two PRs have been cherry-picked to branch-2.8 and included in 2.8.1.10 release.
- https://github.com/apache/pulsar/pull/12305 introduces the support for scope field in OAuth2 authentication.
- https://github.com/apache/pulsar/pull/12341 fixes the incorrect implementation of OAuth2 authentication for some OAuth2 provider like Azure.

This PR adds the related examples for C++ and Python client.

In addition, this PR introduces a better way to configure OAuth2 params for C++ client by passing a `ParamMap` object.